### PR TITLE
Added Python 3.10 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 __pycache__
 docs/
+build/
+protlib.egg-info/
+setup.struct_log
+setup.error_log

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     description = "library for implementing binary network protocols",
     license = "BSD",
     url = "http://pythonhosted.org/protlib/",
+    use_2to3=True,
     test_suite="unit_tests",
     long_description = """
 protlib makes it easy to implement binary network protocols. It uses

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name = "protlib",
-    version = "1.4",
+    version = "1.5.0",
     py_modules = ["protlib"],
     cmdclass = {'build_py': build_py},
     
@@ -21,7 +21,7 @@ setup(
     description = "library for implementing binary network protocols",
     license = "BSD",
     url = "http://pythonhosted.org/protlib/",
-    
+    test_suite="unit_tests",
     long_description = """
 protlib makes it easy to implement binary network protocols. It uses
 the struct and SocketServer modules from the standard library. It
@@ -30,7 +30,7 @@ arrays of structs, better handling for strings and arrays, struct
 inheritance, and convenient syntax for instantiating and using your 
 custom structs.
 
-protlib requires Python 2.6 or later and works in Python 3
+protlib requires Python 2.7 or later and works in Python 3.
 """,
     classifiers = [
         "Programming Language :: Python",

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -20,10 +20,11 @@ Here's an example of defining, instantiating, writing, and reading a struct usin
 .. code-block:: python
 
     from protlib import *
+
     class Point(CStruct):
         x = CInt()
         y = CInt()
-    
+
     p1 = Point(5, 6)
     p2 = Point(x=5, y=6)
     p3 = Point(y=6, x=5)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -19,6 +19,7 @@ from protlib import *
 if sys.version_info[0] == 2:
     from StringIO import StringIO as BytesIO
 else:
+    unicode = str
     from io import BytesIO
 
 warnings.simplefilter("error", CWarning)


### PR DESCRIPTION
Evidently more recent versions of Python have removed the deprecated

```
raise ErrorClass, err, tb
```

syntax.  The current best practice for older projects us to use something like ``six``, which in this case would let me use ``six.raise_from`` to work in both places, but protlib predates six and currently has no dependencies, so I don't want to add a dependency now.

Instead I've just eliminated the use of that syntax.  This does mean that Python 2.7 tracebacks will have slightly less context, but the ``CError`` message strings are extremely detailed, so hopefully this won't be much of a burden, and people can pin to the older version if they want.  (Frankly at this point I should probably just drop support for Python 2.7, but that's a bigger change than I'd want to make here.)